### PR TITLE
Experimental aleph HTTP client support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [compojure "1.3.4" :exclusions [clj-time]]
                  [javax.servlet/servlet-api "2.5"]
                  [ring-cors "0.1.7"]
+                 [aleph "0.4.4"]
                  [fullcontact/camelsnake "0.9.0"]
                  [fullcontact/full.json "0.10.1"]
                  [fullcontact/full.metrics "0.11.4"]

--- a/src/full/http/client.clj
+++ b/src/full/http/client.clj
@@ -178,7 +178,7 @@
   "Performs asynchronous API request. Returns Manifold deferred which contains
    either respose or throwable with error."
   [{:keys [body method timeout form-params body-json-key-fn response-parser
-           follow-redirects?]
+           follow-redirects? basic-auth oauth-token headers]
     :as req-map
     :or {body-json-key-fn ->camelCase
          response-parser kebab-case-json-response-parser
@@ -187,6 +187,9 @@
         method (or method (if (json-body? body) :post :get))]
     (-> (aleph/request {:request-method method
                         :body (aleph-req-body req-map)
+                        :oauth-token oauth-token
+                        :basic-auth basic-auth
+                        :headers (request-headers body headers)
                         :follow-redirects? follow-redirects?
                         :url full-url})
         (d/timeout! (* (or timeout @http-timeout) 1000))

--- a/src/full/http/client.clj
+++ b/src/full/http/client.clj
@@ -169,19 +169,11 @@
   (str (or url (str base-url "/" resource))
        (when params "?" (query-string params))))
 
-(defn- aleph-req-body
-  [{:keys [body form-params body-json-key-fn]
-    :or {body-json-key-fn ->camelCase}}]
-  (cond
-    body (request-body body :json-key-fn body-json-key-fn)
-    form-params (query-string form-params)
-    :else nil))
-
 (defn aleph-req
   "Performs asynchronous API request. Returns Manifold deferred which contains
    either respose or throwable with error."
   [{:keys [body method timeout form-params body-json-key-fn response-parser
-           follow-redirects? basic-auth oauth-token headers]
+           form-params follow-redirects? basic-auth oauth-token headers]
     :as req-map
     :or {body-json-key-fn ->camelCase
          response-parser kebab-case-json-response-parser
@@ -191,7 +183,9 @@
     (-> (aleph/request {:request-method method
                         :body (aleph-req-body req-map)
                         :oauth-token oauth-token
+                        :body (request-body body :json-key-fn body-json-key-fn)
                         :basic-auth basic-auth
+                        :form-params form-params
                         :headers (request-headers body headers)
                         :follow-redirects? follow-redirects?
                         :url full-url})


### PR DESCRIPTION
This adds 2 new methods:

`full.http/aleph-req` - performs async HTTP w/ aleph HTTP client request and returns [Mainfold deferred](https://github.com/ztellman/manifold/blob/master/docs/deferred.md)
`full.http/aleph-req>` - performs async HTTP request w/ aleph HTTP client and returns core.async channel with the value

Multipart requests are not yet supported. Nothing changes in terms of method signature & paylaod building / response parsing, so swapping `full.http.client/req>` to `full.http.client/aleph-req>` will just work.