### PR TITLE
allow top level arrays in json serialization

### DIFF
--- a/src/full/http/client.clj
+++ b/src/full/http/client.clj
@@ -39,7 +39,7 @@
 ;;; REQUEST / RESPONSE HANDLING
 
 (defn json-body? [body]
-  (and body (map? body)))
+  (and body (or (map? body) (sequential? body))))
 
 (defn- request-body
   [body & {:keys [json-key-fn] :or {json-key-fn ->camelCase}}]


### PR DESCRIPTION
Since top level arrays are [valid json](https://www.ietf.org/rfc/rfc4627.txt) and some endpoints require such payloads.